### PR TITLE
eclecticapps.plist: Add Bailiff

### DIFF
--- a/eclecticapps.plist
+++ b/eclecticapps.plist
@@ -210,5 +210,13 @@
 		<key>URL</key>
 		<string>https://eclecticlightdotcom.files.wordpress.com/2021/01/stibium10.zip</string>
 	</dict>
+	<dict>
+		<key>AppName</key>
+		<string>Bailiff</string>
+		<key>Version</key>
+		<string>1.5</string>
+		<key>URL</key>
+		<string>https://eclecticlightdotcom.files.wordpress.com/2020/08/bailiff15.zip</string>
+	</dict>
 </array>
 </plist>


### PR DESCRIPTION
Reading https://github.com/hoakleyelc/updates/issues/1#issuecomment-721895269, it becomes clear Bailiff is missing because you either:

* Forgot to add it.
* Deliberately haven’t added it because it has been discontinued.
* Deliberately haven’t added it because it’s seldom updated.

I’m guessing the last one. Still, it makes sense to submit the PR in case it’s the first one.